### PR TITLE
Use real signing for tagged releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,9 @@ variables:
   # If the user didn't override the signing type, then only real-sign on main.
   ${{ if ne(parameters.SignTypeOverride, 'default') }}:
     SignType: ${{ parameters.SignTypeOverride }}
-  ${{ if and(eq(parameters.SignTypeOverride, 'default'), eq(variables['Build.SourceBranchName'], 'main')) }}:
+  ${{ if and(eq(parameters.SignTypeOverride, 'default'), or(eq(variables['Build.SourceBranchName'], 'main'), startsWith(variables['Build.SourceBranch'], 'refs/tags'))) }}:
     SignType: real
-  ${{ if and(eq(parameters.SignTypeOverride, 'default'), ne(variables['Build.SourceBranchName'], 'main')) }}:
+  ${{ if and(eq(parameters.SignTypeOverride, 'default'), not(or(eq(variables['Build.SourceBranchName'], 'main'), startsWith(variables['Build.SourceBranch'], 'refs/tags')))) }}:
     SignType: test
 
 steps:
@@ -173,7 +173,7 @@ steps:
         $(OutputDirectory)\cella.tgz
         $(OutputDirectory)\signature.cat
       isPreRelease: true
-    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
 
   - task: MicroBuildCleanup@1
     displayName: Clean up MicroBuild


### PR DESCRIPTION
When building from a tag, Azure Pipelines uses the `refs/tags/*` as the branch name. This PR fixes the build pipeline to real-sign an d publish to GitHub in that case.