### PR TITLE
Add NOTICE to build pipeline and version command

### DIFF
--- a/assets/scripts/cella
+++ b/assets/scripts/cella
@@ -136,6 +136,11 @@ if [ ! -z "$CELLA_REMOVE" ]; then
   if [ -f $CELLA_HOME/cella ]; then 
     rm -f $CELLA_HOME/cella
   fi
+
+  if [ -f $CELLA_HOME/NOTICE.txt ]; then 
+    rm -f $CELLA_HOME/NOTICE.txt
+  fi
+
   # cleanup environment.
   . <(set | grep -i ^CELLA | sed -e 's/[=| |\W].*//;s/^/unset /')
   
@@ -302,7 +307,10 @@ cella_bootstrap_cella() {
   PATH=$OLD_PATH
 
   cp $CELLA_HOME/node_modules/.bin/* .
-  
+
+  # Copy the NOTICE file to $CELLA_HOME to improve discoverability.
+  cp $CELLA_HOME/node_modules/cella/NOTICE.txt .
+
   # go back where we were
   cd $CELLA_PWD
   
@@ -396,6 +404,10 @@ cella() {
 
     if [ -f $CELLA_HOME/cella ]; then 
       rm -f $CELLA_HOME/cella
+    fi
+
+    if [ -f $CELLA_HOME/NOTICE.txt ]; then 
+      rm -f $CELLA_HOME/NOTICE.txt
     fi
 
     # cleanup environment

--- a/assets/scripts/cella.ps1
+++ b/assets/scripts/cella.ps1
@@ -71,6 +71,7 @@ if( $reset -or -$remove ) {
   remove-item -force -ea 0 "${CELLA_HOME}/cella.ps1"
   remove-item -force -ea 0 "${CELLA_HOME}/cella.cmd"
   remove-item -force -ea 0 "${CELLA_HOME}/cella"  
+  remove-item -force -ea 0 "${CELLA_HOME}/NOTICE.txt"
   $error.clear();
 
   if( $remove ) { 
@@ -221,6 +222,9 @@ function bootstrap-cella {
 
   # we should also copy the .bin files into the $CELLA_HOME folder to make reactivation (without being on the PATH) easy
   copy-item ./node_modules/.bin/cella.* 
+
+  # Copy the NOTICE file to $CELLA_HOME to improve discoverability.
+  copy-item ./node_modules/cella/NOTICE.txt
 
   popd
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,14 @@ steps:
   - script: rush deploy
     displayName: Collect dependencies
 
+  # Run Component Governance and inject the NOTICE file.
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: Detect components
+  - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
+    displayName: Generate NOTICE file
+    inputs:
+      outputfile: $(Build.SourcesDirectory)/common/deploy/NOTICE.txt
+
   # Sign JavaScript and PowerShell files.
   - task: NuGetCommand@2
     displayName: Restore MicroBuild Core
@@ -125,8 +133,6 @@ steps:
     displayName: Publish artifacts
 
   # Do final compliance checks.
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: Detect components
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
     displayName: Check for compliance errors
     # To avoid spirious warnings about missing logs, explicitly declare what we scanned.

--- a/cli/lib/commands/version.ts
+++ b/cli/lib/commands/version.ts
@@ -104,6 +104,9 @@ export class VersionCommand extends Command {
     log(i`${cli} version information\n`);
     log(i`  core version: ${Version} `);
     log(i`  cli version: ${cliVersion} `);
+
+    // Make the NOTICE file discoverable. This file is generated during the official build.
+    log(i`Third-party license information is available at ${session.cellaHome.join('NOTICE.txt').fsPath}`);
     return true;
   }
 


### PR DESCRIPTION
Adding the NOTICE file path to the version command is a CELA-approved way to make the file discoverable.