### PR TITLE
Add publishing to public repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ steps:
     displayName: Collect dependencies
 
   # Run Component Governance and inject the NOTICE file.
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  - task: ComponentGovernanceComponentDetection@0
     displayName: Detect components
     inputs:
       ignoreDirectories: common/temp


### PR DESCRIPTION
With these changes the build pipeline will automatically create a release in the vcpkg-ce repo whenever a tag is pushed to this repo. The associated tag in the vcpkg-ce repo will have the same name as the tag in this repo.

We authenticate to the vcpkg-ce repo by using a deploy key. The public key is stored in the repo settings, and the private key is stored in a secret file in Azure Pipelines. In theory it would be possible to reuse the existing `embeddedbot` service connection for authentication (like what the `GitHubRelease` task does), but that seems to be difficult to integrate with unless you write a new Azure Pipelines task.