### PR TITLE
fixed bug where 'ce help <command>' wouldn't work

### DIFF
--- a/cli/lib/commands/help.ts
+++ b/cli/lib/commands/help.ts
@@ -42,7 +42,7 @@ export class HelpCommand extends Command {
   }
 
   async run() {
-    const cmd = ['-h', '-help', '-?', '/?'].find(each => each === this.commandLine.inputs[0]) ? this.commandLine.inputs[1] : this.commandLine.inputs[0];
+    const cmd = ['-h', '-help', '-?', '/?'].find(each => (this.commandLine.inputs.indexOf(each) > -1)) ? this.commandLine.inputs[0] : this.commandLine.inputs[1];
     // did they ask for help on a command?
 
     if (cmd) {


### PR DESCRIPTION
Prior to my change, there was a bug that didn't allow commands like "ce help new" or in general, "ce help <command" to work. It would simply treat it as "ce help".

The problem was that the current line searching for -h, -help, -?, /?, only searched for any of those flags in input[0]. Thus, it always returned false and defaulted to setting the "cmd" value to input[0], which in the failing case of "ce help new" would be "help".

I fixed this by searching for -h, -help, -?, /? in the entire input array, not just input[0]. If one of those flags is in the array, then cmd will be set to input[0], otherwise it will be set to input[1] (for the "ce help <command>" situation).