### PR TITLE
Sign third-party sources

### DIFF
--- a/.scripts/signing/SignFiles.proj
+++ b/.scripts/signing/SignFiles.proj
@@ -16,15 +16,9 @@
     <FilesToSign Include="$(OutDir)\**\ce.ps1">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
-    <!--
-      Unfortunately, there's a problem using the real-signed third-party certificate for Javascript.
-      SignTool Error: Multiple signature support is not implemented for this filetype.
-      While not ideal, it's still okay because later we add a detached signature for the
-      entire tgz, which includes the third-party sources.
-    -->
-    <!-- <FilesToSign Include="$(OutDir)\**\node_modules\**\*.js">
-      <Authenticode>3PartySHA2</Authenticode>
-    </FilesToSign> -->
+    <FilesToSign Include="$(OutDir)\**\node_modules\**\*.js">
+      <Authenticode>3PartyScriptsSHA2</Authenticode>
+    </FilesToSign>
   </ItemGroup>
 
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" />


### PR DESCRIPTION
Microbuild has added a new certificate that supports third-party signing of script files like *.js and *.ps1.