### PR TITLE
Follow the vcpkg Z_ convention for internal things.

### DIFF
--- a/assets/scripts/ce
+++ b/assets/scripts/ce
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
@@ -12,12 +12,12 @@
 # check to see if we've been dot-sourced (should work for most POSIX shells)
 sourced=0
 
-if [ -n "$ZSH_EVAL_CONTEXT" ]; then 
+if [ -n "$ZSH_EVAL_CONTEXT" ]; then
   case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
 elif [ -n "$KSH_VERSION" ]; then
   [ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ] && sourced=1
 elif [ -n "$BASH_VERSION" ]; then
-  (return 0 2>/dev/null) && sourced=1 
+  (return 0 2>/dev/null) && sourced=1
 else # All other shells: examine $0 for known shell binary filenames
   # Detects `sh` and `dash`; add additional shell filenames as needed.
   case ${0##*/} in sh|dash) sourced=1;; esac
@@ -40,7 +40,7 @@ VCPKG_init() {
   VCPKG_OS="$(uname | sed 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')"
   VCPKG_ARCH="$(uname -m | sed -e 's/x86_64/x64/;s/i86pc/x64/;s/i686/x86/;s/aarch64/arm64/')"
 
-  case $VCPKG_OS in 
+  case $VCPKG_OS in
     ( mingw64_nt* | msys_nt* ) VCPKG_OS="win";;
     ( darwin*|*bsd*) VCPKG_IS_THIS_BSD=TRUE;;
     ( aix ) VCPKG_ARCH="ppc64" ;;
@@ -48,7 +48,7 @@ VCPKG_init() {
 
   if [ ! -z "$VCPKG_IS_THIS_BSD" ]; then
     VCPKG_START_TIME=$(date +%s)
-  else 
+  else
     VCPKG_START_TIME=$(($(date +%s%N)/1000000))
   fi
 
@@ -65,12 +65,12 @@ VCPKG_init() {
 VCPKG_init "$@"
 shift $#
 
-# at this point, we're pretty sure we've been dot-sourced 
+# at this point, we're pretty sure we've been dot-sourced
 # Try to locate the $VCPKG_ROOT folder, where the ce is installed.
-if [ -n "$VCPKG_ROOT" ]; then 
-  # specify it on the command line if you like, we'll export it 
+if [ -n "$VCPKG_ROOT" ]; then
+  # specify it on the command line if you like, we'll export it
   export VCPKG_ROOT=$VCPKG_ROOT
-else 
+else
   # default is off the home folder
   export VCPKG_ROOT=~/.vcpkg
 fi;
@@ -95,64 +95,64 @@ VCPKG_debug() {
       echo "[NESTED $OFFSET] $*"
     else
       echo "[$OFFSET] $*"
-    fi  
+    fi
   fi
 
   if [ -n "$VCPKG_NESTED" ]; then
     echo "[NESTED $OFFSET] $*" >> $VCPKG_ROOT/log.txt
   else
     echo "[$OFFSET] $*" >> $VCPKG_ROOT/log.txt
-  fi      
+  fi
 }
 
 if [ ! -z "$VCPKG_RESET" ]; then
-  if [ -d $CE/node_modules ]; then 
+  if [ -d $CE/node_modules ]; then
     echo Forcing reinstall of vcpkg-ce package
     rm -rf $CE/node_modules
   fi
 
-  if [ -d $CE/bin ]; then 
+  if [ -d $CE/bin ]; then
     rm -rf $CE/bin
-  fi 
+  fi
 
-  if [ -d $CE/lib ]; then 
+  if [ -d $CE/lib ]; then
     rm -rf $CE/lib
   fi
 fi
 
 if [ ! -z "$VCPKG_REMOVE" ]; then
-  if [ -d $CE/node_modules ]; then 
+  if [ -d $CE/node_modules ]; then
     echo Removing vcpkg-ce package
     rm -rf $CE/node_modules
   fi
 
-  if [ -d $CE/bin ]; then 
+  if [ -d $CE/bin ]; then
     rm -rf $CE/bin
-  fi 
+  fi
 
-  if [ -d $CE/lib ]; then 
+  if [ -d $CE/lib ]; then
     rm -rf $CE/lib
   fi
 
-  if [ -f $VCPKG_ROOT/ce.ps1 ]; then 
+  if [ -f $VCPKG_ROOT/ce.ps1 ]; then
     rm -f $VCPKG_ROOT/ce.ps1
   fi
 
-  if [ -f $VCPKG_ROOT/ce ]; then 
+  if [ -f $VCPKG_ROOT/ce ]; then
     rm -f $VCPKG_ROOT/ce
   fi
 
-  if [ -f $VCPKG_ROOT/NOTICE.txt ]; then 
+  if [ -f $VCPKG_ROOT/NOTICE.txt ]; then
     rm -f $VCPKG_ROOT/NOTICE.txt
   fi
 
-  if [ -f $VCPKG_ROOT/LICENSE.txt ]; then 
+  if [ -f $VCPKG_ROOT/LICENSE.txt ]; then
     rm -f $VCPKG_ROOT/LICENSE.txt
   fi
 
   # cleanup environment.
   . <(set | grep -i ^VCPKG | sed -e 's/[=| |\W].*//;s/^/unset /')
-  
+
   # remove functions (zsh)
   which functions  > /dev/null 2>&1  && . <(functions | grep -i ^vcpkg | sed -e 's/[=| |\W].*//;s/^/unset -f /')
   return
@@ -175,10 +175,10 @@ VCPKG_cleanup() {
   unset VCPKG_RESET
   unset VCPKG_START_TIME
   unset VCPKG_ARGS
-  if [ -f "${VCPKG_POSTSCRIPT}" ]; then
-    command rm "${VCPKG_POSTSCRIPT}"
+  if [ -f "${Z_VCPKG_POSTSCRIPT}" ]; then
+    command rm "${Z_VCPKG_POSTSCRIPT}"
   fi
-	unset VCPKG_POSTSCRIPT
+	unset Z_VCPKG_POSTSCRIPT
 }
 
 VCPKG_bootstrap_node() {
@@ -204,19 +204,19 @@ VCPKG_bootstrap_node() {
 
 
   # we don't have a good node in the path
-  # we would install one here if we tried 
+  # we would install one here if we tried
   # before
   VCPKG_NODE=${CE}/bin/node
-  
-  if [ -f $VCPKG_NODE ]; then 
+
+  if [ -f $VCPKG_NODE ]; then
     if [ `$VCPKG_NODE -e "[major, minor, patch ] = process.versions.node.split('.'); console.log( !!(major>16 || major == 16 & minor >= 12))"` = "true" ]; then
       # looks good, lets grab NPM in case we need it, and get out.
       VCPKG_NPM=`which ${CE}/bin/npm`
-      VCPKG_debug using node from ce 
+      VCPKG_debug using node from ce
       return 0
-    fi 
+    fi
   fi
-  
+
   # we don't seem to have a suitable nodejs on the path
   # let's grab a well-known one, cache it and use it.
 
@@ -229,7 +229,7 @@ VCPKG_bootstrap_node() {
   local NODE_FULLNAME="node-v${VCPKG_NODE_LATEST}-${VCPKG_OS}-${VCPKG_ARCH}"
   local NODE_URI="${VCPKG_NODE_REMOTE}v${VCPKG_NODE_LATEST}/${NODE_FULLNAME}${VCPKG_ARCHIVE_EXT}"
   local VCPKG_ARCHIVE="${CE}/files/${NODE_FULLNAME}${VCPKG_ARCHIVE_EXT}"
-  
+
   if [ ! -d "${CE}/files" ]; then
     command mkdir -p "${CE}/files"
   fi
@@ -245,7 +245,7 @@ VCPKG_bootstrap_node() {
     echo "Failed to download node binary."
     return 1
   fi
-    
+
   # UNPACK IT
   if [ "${VCPKG_OS}" = "aix" ]; then
     gunzip "${VCPKG_ARCHIVE}" | tar -xvC "${CE}" "${NODE_FULLNAME}/bin/${NODE_EXE}" >> $VCPKG_ROOT/log.txt 2>&1
@@ -268,7 +268,7 @@ VCPKG_bootstrap_node() {
       echo ""
       echo "run (as root): "
       echo "   pkg install -y node16"
-      echo "   pkg install -y npm-node16" 
+      echo "   pkg install -y npm-node16"
     fi
     return 1;
   fi
@@ -298,7 +298,7 @@ VCPKG_bootstrap_ce() {
 
   # ensure we have a node_modules here, so npm won't search for one up the tree.
   command mkdir -p $CE/node_modules
-  
+
   echo Installing vcpkg-ce in $VCPKG_ROOT
   unset VCPKG_RESET
 
@@ -308,7 +308,7 @@ VCPKG_bootstrap_ce() {
   PATH=`dirname $VCPKG_NODE`:$PATH
   if [ ! -z "$USE_LOCAL_VCPKG_PKG" ]; then
     echo USING LOCAL CE PACKAGE $USE_LOCAL_VCPKG_PKG
-    
+
     $VCPKG_NODE $VCPKG_NPM --force install --no-save --no-lockfile --scripts-prepend-node-path=true $USE_LOCAL_VCPKG_PKG  >> $VCPKG_ROOT/log.txt 2>&1
   else
     $VCPKG_NODE $VCPKG_NPM --force install --no-save --no-lockfile --scripts-prepend-node-path=true https://aka.ms/vcpkg-ce.tgz  >> $VCPKG_ROOT/log.txt 2>&1
@@ -323,7 +323,7 @@ VCPKG_bootstrap_ce() {
   # Copy the NOTICE and LICENSE files to $VCPKG_ROOT to improve discoverability.
   cp $CE/node_modules/vcpkg-ce/NOTICE.txt $VCPKG_ROOT/
   cp $CE/node_modules/vcpkg-ce/LICENSE.txt $VCPKG_ROOT/
-  
+
   if [  ! -f $VCPKG_SCRIPT ]; then
     echo "ERROR! Unable to find/get ce script command $VCPKG_SCRIPT"
     return 1;
@@ -355,7 +355,7 @@ if [ -z $VCPKG_NESTED ]; then
   VCPKG_debug executing final script: $VCPKG_SCRIPT
   VCPKG_NESTED=TRUE
   . $VCPKG_SCRIPT $VCPKG_ARGS
-  return # let the real script take over from here. 
+  return # let the real script take over from here.
 fi
 
 # So, we're the real script then.
@@ -369,20 +369,20 @@ ce() {
   VCPKG_init "$@"
 
   if [ ! -z "$VCPKG_RESET" ]; then
-    if [ -d $CE/node_modules ]; then 
+    if [ -d $CE/node_modules ]; then
       echo Forcing reinstall of vcpkg-ce package
       rm -rf $CE/node_modules
     fi
 
-    if [ -d $CE/bin ]; then 
+    if [ -d $CE/bin ]; then
       rm -rf $CE/bin
-    fi 
+    fi
 
-    if [ -d $CE/lib ]; then 
+    if [ -d $CE/lib ]; then
       rm -rf $CE/lib
     fi
     unset VCPKG_RESET
-    
+
     if [ ! -z "$USE_LOCAL_VCPKG_SCRIPT" ]; then
       echo USING LOCAL CE SCRIPT $USE_LOCAL_VCPKG_SCRIPT
       . <(cat $USE_LOCAL_VCPKG_SCRIPT) "${VCPKG_ARGS[@]}"
@@ -394,39 +394,39 @@ ce() {
   fi
 
   if [ ! -z "$VCPKG_REMOVE" ]; then
-    if [ -d $CE/node_modules ]; then 
+    if [ -d $CE/node_modules ]; then
       unset VCPKG_REMOVE
       echo Removing vcpkg-ce package
       rm -rf $CE/node_modules
     fi
 
-    if [ -d $CE/bin ]; then 
+    if [ -d $CE/bin ]; then
       rm -rf $CE/bin
-    fi 
+    fi
 
-    if [ -d $CE/lib ]; then 
+    if [ -d $CE/lib ]; then
       rm -rf $CE/lib
     fi
 
-    if [ -f $VCPKG_ROOT/ce.ps1 ]; then 
+    if [ -f $VCPKG_ROOT/ce.ps1 ]; then
       rm -f $VCPKG_ROOT/ce.ps1
     fi
 
-    if [ -f $VCPKG_ROOT/ce ]; then 
+    if [ -f $VCPKG_ROOT/ce ]; then
       rm -f $VCPKG_ROOT/ce
     fi
 
-    if [ -f $VCPKG_ROOT/NOTICE.txt ]; then 
+    if [ -f $VCPKG_ROOT/NOTICE.txt ]; then
       rm -f $VCPKG_ROOT/NOTICE.txt
     fi
 
-    if [ -f $VCPKG_ROOT/LICENSE.txt ]; then 
+    if [ -f $VCPKG_ROOT/LICENSE.txt ]; then
       rm -f $VCPKG_ROOT/LICENSE.txt
     fi
 
     # cleanup environment
     . <(set | grep -i ^VCPKG | sed -e 's/[=| |\W].*//;s/^/unset /')
-    
+
     # remove functions (zsh)
     which functions  > /dev/null 2>&1  && . <(functions | grep -i ^vcpkg | sed -e 's/[=| |\W].*//;s/^/unset -f /')
     return 0
@@ -445,21 +445,21 @@ ce() {
 
   # set the response file
 	# Generate 32 bits of randomness, to avoid clashing with concurrent executions.
-	export VCPKG_POSTSCRIPT="${VCPKG_ROOT}/VCPKG_tmp_$(dd if=/dev/urandom count=1 2> /dev/null | cksum | cut -f1 -d" ").sh"
+	export Z_VCPKG_POSTSCRIPT="${VCPKG_ROOT}/VCPKG_tmp_$(dd if=/dev/urandom count=1 2> /dev/null | cksum | cut -f1 -d" ").sh"
 
   # call ce.js
-  # it picks up the VCPKG_POSTSCRIPT environment variable to know where to dump the postscript
+  # it picks up the Z_VCPKG_POSTSCRIPT environment variable to know where to dump the postscript
   $VCPKG_NODE --harmony $VCPKG_MAIN ${VCPKG_ARGS[@]}
-  
+
   VCPKG_debug called ce.js
-  # modify the environment 
+  # modify the environment
 
   # Call the post-invocation script if it is present, then delete it.
 	# This allows the invocation to potentially modify the caller's environment (e.g. PATH)
-	if [ -f "${VCPKG_POSTSCRIPT}" ]; then
-		. "${VCPKG_POSTSCRIPT}"
-		command rm "${VCPKG_POSTSCRIPT}"
-		unset VCPKG_POSTSCRIPT
+	if [ -f "${Z_VCPKG_POSTSCRIPT}" ]; then
+		. "${Z_VCPKG_POSTSCRIPT}"
+		command rm "${Z_VCPKG_POSTSCRIPT}"
+		unset Z_VCPKG_POSTSCRIPT
 	fi
 
   VCPKG_cleanup
@@ -468,7 +468,7 @@ ce() {
 }
 
 # did they dotsource and have args go ahead and run it then!
-if [ -n "$VCPKG_ARGS" ]; then 
+if [ -n "$VCPKG_ARGS" ]; then
   ce "${VCPKG_ARGS[@]}"
 fi
 

--- a/assets/scripts/ce.ps1
+++ b/assets/scripts/ce.ps1
@@ -1,4 +1,4 @@
-@(echo off) > $null 
+@(echo off) > $null
 if #ftw NEQ '' goto :init
 ($true){ $Error.clear(); }
 
@@ -9,9 +9,9 @@ if #ftw NEQ '' goto :init
 # this is intended to be dot-sourced and then you can use the ce() function
 
 # unpack arguments if they came from CMD
-$hash=@{}; 
+$hash=@{};
 get-item env:argz* |% { $hash[$_.name] = $_.value }
-if ($hash.count -gt 0) { 
+if ($hash.count -gt 0) {
   $args=for ($i=0; $i -lt $hash.count;$i++) { $hash["ARGZ[$i]"] }
 }
 # force the array to be an arraylist since we like to mutate it.
@@ -34,34 +34,34 @@ function Invoke-Assignment {
       if (eval($args[0])) { return eval($args[$p]) }  # ternary true
       return eval($args[([array]::IndexOf($args,':',$p))+1])  # ternary false
     }
-          
+
     # null-coalescing
     if ($p = ([array]::IndexOf($args,'??',$p)+1)) {
-      if ($result = eval($args[0])) { return $result }  # first arg true 
+      if ($result = eval($args[0])) { return $result }  # first arg true
       return eval($args[$p]) # first arg false
-    } 
-          
-    # neither ternary or null-coalescing, just a value  
+    }
+
+    # neither ternary or null-coalescing, just a value
     return eval($args[0])
   }
   return $null
 }
 
 # alias the function to the equals sign (which doesn't impede the normal use of = )
-set-alias = Invoke-Assignment 
+set-alias = Invoke-Assignment
 
-function resolve([string]$name) { 
+function resolve([string]$name) {
   $name = Resolve-Path $name -ErrorAction 0 -ErrorVariable _err
   if (-not($name)) { return $_err[0].TargetObject }
   $Error.clear()
   return $name
 }
 
-$SCRIPT:DEBUG=( $args.indexOf('--debug') -gt -1 ) 
+$SCRIPT:DEBUG=( $args.indexOf('--debug') -gt -1 )
 
 function ce-debug() {
   $t = [int32]((get-date).Subtract(($VCPKG_START_TIME)).ticks/10000)
-  if($SCRIPT:DEBUG) { 
+  if($SCRIPT:DEBUG) {
     write-host -fore green "[$t msec] " -nonewline
     write-host -fore gray $args
   }
@@ -72,11 +72,11 @@ function download($url, $path) {
   $wc = New-Object net.webclient
 
   if( test-path -ea 0 $path) {
-    # check to see if the size is a match before downloading 
+    # check to see if the size is a match before downloading
     $s = $wc.OpenRead($url)
     $len = $wc.ResponseHeaders['Content-Length']
     $s.Dispose()
-    if( (get-item $path).Length -eq $len ){ 
+    if( (get-item $path).Length -eq $len ){
       $wc.Dispose();
       ce-debug "skipping download of '$url' - '$path' is ok."
       return $path;
@@ -92,8 +92,8 @@ function download($url, $path) {
   return $path
 }
 
-# set the home path. 
-if( $ENV:VCPKG_ROOT ) { 
+# set the home path.
+if( $ENV:VCPKG_ROOT ) {
   $SCRIPT:VCPKG_ROOT=(resolve $ENV:VCPKG_ROOT)
   $ENV:VCPKG_ROOT=$VCPKG_ROOT
 } else {
@@ -106,8 +106,8 @@ $MODULES= "$CE/node_modules"
 $SCRIPT:VCPKG_SCRIPT=(resolve $MODULES/.bin/ce.ps1)
 $SCRIPT:CE_MODULE=(resolve $MODULES/vcpkg-ce )
 
-$reset = $args.IndexOf('--reset-ce') -gt -1 
-$remove = $args.IndexOf('--remove-ce') -gt -1 
+$reset = $args.IndexOf('--reset-ce') -gt -1
+$remove = $args.IndexOf('--remove-ce') -gt -1
 
 if( $reset -or -$remove ) {
   $args.remove('--reset-ce');
@@ -121,7 +121,7 @@ if( $reset -or -$remove ) {
   remove-item -force -ea 0 "${VCPKG_ROOT}/ce.ps1","${VCPKG_ROOT}/ce.cmd","${VCPKG_ROOT}/ce","${VCPKG_ROOT}/NOTICE.txt","${VCPKG_ROOT}/LICENSE.txt"
   $error.clear();
 
-  if( $remove ) { 
+  if( $remove ) {
     write-host "Removing vcpkg-ce"
     exit
   }
@@ -129,10 +129,10 @@ if( $reset -or -$remove ) {
 
 function verify-node($NODE) {
   if( $NODE -and (get-command -ea 0 $NODE) -and ( (& $NODE -p "/(^\d*\.\d*)/g.exec( process.versions.node)[0]") -ge 16.12 ) ) {
-    # it's a good version of node, let's set the variables 
+    # it's a good version of node, let's set the variables
     $SCRIPT:VCPKG_NODE=$NODE
     $error.clear();
-    return $TRUE;  
+    return $TRUE;
   }
   $error.clear();
   return $FALSE
@@ -152,8 +152,8 @@ function bootstrap-node {
   }
 
   # not there, or not good enough
-  if((($PSVersionTable.OS -match "windows") -or ($PSVersionTable.PSEdition -match 'desktop') ) ) {   # windows 
-    $NODE_OS='win' 
+  if((($PSVersionTable.OS -match "windows") -or ($PSVersionTable.PSEdition -match 'desktop') ) ) {   # windows
+    $NODE_OS='win'
     switch($ENV:PROCESSOR_ARCHITECTURE) {
       'AMD64' { $NODE_ARCH='x64' }
       'ARM64' { $NODE_ARCH='arm64' }
@@ -163,39 +163,39 @@ function bootstrap-node {
   } else {
     $NODE_OS=(uname | sed 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
     $NODE_ARCH=(uname -m | sed -e 's/x86_64/x64/;s/i86pc/x64/;s/i686/x86/;s/aarch64/arm64/')
-    if ( $NODE_OS -eq "aix" ) { $NODE_ARCH="ppc64" } #aix special 
+    if ( $NODE_OS -eq "aix" ) { $NODE_ARCH="ppc64" } #aix special
     $NODE_ARCHIVE_EXT=".tar.gz"
   }
 
   $NODE_FULLNAME="node-v${VCPKG_NODE_LATEST}-${NODE_OS}-${NODE_ARCH}"
   $NODE_URI="${VCPKG_NODE_REMOTE}v${VCPKG_NODE_LATEST}/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"
   $NODE_ARCHIVE= resolve "$CE/files/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"
-  
+
   $ProgressPreference = 'SilentlyContinue'
   ce-debug "Downloading Node: ${NODE_URI}"
   download $NODE_URI $NODE_ARCHIVE
 
   switch($NODE_OS){
-    'win' { 
+    'win' {
       if( get-command -ea 0 tar.exe ) {
         tar "-xvf" "${NODE_ARCHIVE}" -C "${CE}"  2>&1  > $null
       } else {
-        $shh= expand-archive -path $NODE_ARCHIVE -destinationpath "${CE}" 
+        $shh= expand-archive -path $NODE_ARCHIVE -destinationpath "${CE}"
       }
-      move-item "$CE/${NODE_FULLNAME}" "$CE/bin" 
+      move-item "$CE/${NODE_FULLNAME}" "$CE/bin"
     }
-    'aix' { 
-      $shh = gunzip "${NODE_ARCHIVE}" | tar -xvC "${CE}" "${NODE_FULLNAME}/bin/${NODE_EXE}" 
-      move-item "$CE/${NODE_FULLNAME}/bin" "$CE/" 
-      move-item "$CE/${NODE_FULLNAME}/lib" "$CE/"  
-      remove-item "$CE/${NODE_FULLNAME}" -force -recurse 
-    } 
-    default { 
-      $shh = tar "-zxvf" "${NODE_ARCHIVE}" -C "${CE}"  
-      move-item "$CE/${NODE_FULLNAME}/bin" "$CE/" 
-      move-item "$CE/${NODE_FULLNAME}/lib" "$CE/"   
-      remove-item "$CE/${NODE_FULLNAME}" -force -recurse 
-    } 
+    'aix' {
+      $shh = gunzip "${NODE_ARCHIVE}" | tar -xvC "${CE}" "${NODE_FULLNAME}/bin/${NODE_EXE}"
+      move-item "$CE/${NODE_FULLNAME}/bin" "$CE/"
+      move-item "$CE/${NODE_FULLNAME}/lib" "$CE/"
+      remove-item "$CE/${NODE_FULLNAME}" -force -recurse
+    }
+    default {
+      $shh = tar "-zxvf" "${NODE_ARCHIVE}" -C "${CE}"
+      move-item "$CE/${NODE_FULLNAME}/bin" "$CE/"
+      move-item "$CE/${NODE_FULLNAME}/lib" "$CE/"
+      remove-item "$CE/${NODE_FULLNAME}" -force -recurse
+    }
   }
 
   if( (verify-node (resolve "$CE/bin/node"))) {
@@ -204,7 +204,7 @@ function bootstrap-node {
   }
 
   write-error 'Unable to resolve nodejs'
-  return $FALSE; 
+  return $FALSE;
 }
 
 function bootstrap-vcpkg-ce {
@@ -212,7 +212,7 @@ function bootstrap-vcpkg-ce {
     return $TRUE;
   }
 
-  ## if we're running from an installed module location, we'll keep that. 
+  ## if we're running from an installed module location, we'll keep that.
   $MODULE=(resolve ${PSScriptRoot}/CE/node_modules/vcpkg-ce )
 
   if( test-path $MODULE ) {
@@ -220,24 +220,24 @@ function bootstrap-vcpkg-ce {
     return $TRUE
   }
 
-  # cleanup the yarn cache. 
+  # cleanup the yarn cache.
   ce-debug "Clearing YARN cache"
-  $shh = & $VCPKG_NODE $YARN cache clean --force 2>&1 
+  $shh = & $VCPKG_NODE $YARN cache clean --force 2>&1
   $error.clear();
 
   write-host "Installing vcpkg-ce to ${VCPKG_ROOT}"
 
   $PKG == $USE_LOCAL_VCPKG_PKG ?? https://aka.ms/vcpkg-ce.tgz
   pushd $CE
-  
+
   $PATH = $ENV:PATH
   $ENV:PATH="C:\Users\garre\.vcpkg\ce\bin\;$PATH"
   # &$VCPKG_NODE $NPM install $PKG --no-lockfile --force --verbose 2>&1 >> $VCPKG_ROOT/log.txt
   &$VCPKG_NODE $YARN add $PKG --no-lockfile --force --scripts-prepend-node-path=true --modules-folder=$MODULES 2>&1 >> $VCPKG_ROOT/log.txt
   $ENV:PATH = $PATH
 
-  remove-item -path $ce/package.json -ea 0 
-  
+  remove-item -path $ce/package.json -ea 0
+
   popd
   # 2>&1 >> $VCPKG_ROOT/log.txt
   ce-debug 'yarn finished.'
@@ -276,23 +276,23 @@ if( -not (bootstrap-node )) {
   throw "Installation Unsuccessful."
 }
 
-if( -not (bootstrap-vcpkg-ce )) { 
+if( -not (bootstrap-vcpkg-ce )) {
   write-error "Unable to install vcpkg-ce."
   throw "Installation Unsuccessful."
 }
 
 # export vcpkg-ce to the current shell.
-$shh = New-Module -name vcpkg-ce -ArgumentList @($VCPKG_NODE,$CE_MODULE,$VCPKG_ROOT) -ScriptBlock { 
-  param($VCPKG_NODE,$CE_MODULE,$VCPKG_ROOT) 
+$shh = New-Module -name vcpkg-ce -ArgumentList @($VCPKG_NODE,$CE_MODULE,$VCPKG_ROOT) -ScriptBlock {
+  param($VCPKG_NODE,$CE_MODULE,$VCPKG_ROOT)
 
-  function resolve([string]$name) { 
+  function resolve([string]$name) {
     $name = Resolve-Path $name -ErrorAction 0 -ErrorVariable _err
     if (-not($name)) { return $_err[0].TargetObject }
     $Error.clear()
     return $name
   }
 
-  function ce() { 
+  function ce() {
     if( ($args.indexOf('--remove-ce') -gt -1) -or ($args.indexOf('--reset-ce') -gt -1)) {
       # we really want to do call the ps1 script to do this.
       if( test-path "${VCPKG_ROOT}/ce.ps1" ) {
@@ -310,20 +310,20 @@ $shh = New-Module -name vcpkg-ce -ArgumentList @($VCPKG_NODE,$CE_MODULE,$VCPKG_R
 
     # setup the postscript file
     # Generate 31 bits of randomness, to avoid clashing with concurrent executions.
-    $env:VCPKG_POSTSCRIPT = resolve "${VCPKG_ROOT}/VCPKG_tmp_$(Get-Random -SetSeed $PID).ps1"
+    $env:Z_VCPKG_POSTSCRIPT = resolve "${VCPKG_ROOT}/VCPKG_tmp_$(Get-Random -SetSeed $PID).ps1"
 
-    & $VCPKG_NODE --harmony $CE_MODULE @args  
+    & $VCPKG_NODE --harmony $CE_MODULE @args
 
     # dot-source the postscript file to modify the environment
-    if ($env:VCPKG_POSTSCRIPT -and (Test-Path $env:VCPKG_POSTSCRIPT)) {
-      # write-host (get-content -raw $env:VCPKG_POSTSCRIPT)
-      $postscr = get-content -raw $env:VCPKG_POSTSCRIPT
+    if ($env:Z_VCPKG_POSTSCRIPT -and (Test-Path $env:Z_VCPKG_POSTSCRIPT)) {
+      # write-host (get-content -raw $env:Z_VCPKG_POSTSCRIPT)
+      $postscr = get-content -raw $env:Z_VCPKG_POSTSCRIPT
       if( $postscr ) {
         iex $postscr
       }
-      Remove-Item -Force -ea 0 $env:VCPKG_POSTSCRIPT,env:VCPKG_POSTSCRIPT
+      Remove-Item -Force -ea 0 $env:Z_VCPKG_POSTSCRIPT,env:Z_VCPKG_POSTSCRIPT
     }
-  }  
+  }
 }
 
 # finally, if this was run with some arguments, then let's just pass it
@@ -331,23 +331,23 @@ if( $args.length -gt 0 ) {
   ce @args
 }
 
-return 
-<# 
-:set 
+return
+<#
+:set
 set ARGZ[%i%]=%1&set /a i+=1 & goto :eof
 
-:unset 
+:unset
 set %1=& goto :eof
 
 :init
 if exist $null erase $null
 
 :: do anything we need to before calling into powershell
-if exist $null erase $null 
+if exist $null erase $null
 
 IF "%VCPKG_ROOT%"=="" SET VCPKG_ROOT=%USERPROFILE%\.vcpkg
 
-if exist %~dp0ce\node_modules\vcpkg-ce\package.json ( 
+if exist %~dp0ce\node_modules\vcpkg-ce\package.json (
   :: we're running the wrapper script for a module-installed vcpkg-ce
   set VCPKG_CMD=%~dpf0
   set VCPKG_MODULE=%~dp0ce\node_modules\vcpkg-ce
@@ -361,7 +361,7 @@ set VCPKG_CMD=%VCPKG_ROOT%\ce\node_modules\vcpkg-ce\ce.cmd
 if "%1" EQU "--reset-ce" goto BOOTSTRAP
 
 :: if we're being asked to remove the install, call bootstrap
-if "%1" EQU "--remove-ce" ( 
+if "%1" EQU "--remove-ce" (
   set REMOVE_CE=TRUE
   doskey ce=
   goto BOOTSTRAP
@@ -382,27 +382,27 @@ goto :eof
 
 :INVOKE
 :: Generate 30 bits of randomness, to avoid clashing with concurrent executions.
-SET /A VCPKG_POSTSCRIPT=%RANDOM% * 32768 + %RANDOM%
-SET VCPKG_POSTSCRIPT=%VCPKG_ROOT%\VCPKG_tmp_%VCPKG_POSTSCRIPT%.cmd
+SET /A Z_VCPKG_POSTSCRIPT=%RANDOM% * 32768 + %RANDOM%
+SET Z_VCPKG_POSTSCRIPT=%VCPKG_ROOT%\VCPKG_tmp_%Z_VCPKG_POSTSCRIPT%.cmd
 
 :: find the right node
 if exist %VCPKG_ROOT%\ce\bin\node.exe set VCPKG_NODE=%VCPKG_ROOT%\ce\bin\node.exe
-if "%VCPKG_NODE%" EQU "" ( 
-  for %%i in (node.exe) do set VCPKG_NODE=%%~$PATH:i      
+if "%VCPKG_NODE%" EQU "" (
+  for %%i in (node.exe) do set VCPKG_NODE=%%~$PATH:i
 )
 if "%VCPKG_NODE%" EQU "" goto OHNONONODE:
 
 :: call the program
-"%VCPKG_NODE%" --harmony "%VCPKG_MODULE%" %* 
+"%VCPKG_NODE%" --harmony "%VCPKG_MODULE%" %*
 set VCPKG_EXITCODE=%ERRORLEVEL%
 doskey ce="%VCPKG_CMD%" $*
 
 :POSTSCRIPT
 :: Call the post-invocation script if it is present, then delete it.
 :: This allows the invocation to potentially modify the caller's environment (e.g. PATH).
-IF NOT EXIST "%VCPKG_POSTSCRIPT%" GOTO :fin
-CALL "%VCPKG_POSTSCRIPT%"
-DEL "%VCPKG_POSTSCRIPT%"
+IF NOT EXIST "%Z_VCPKG_POSTSCRIPT%" GOTO :fin
+CALL "%Z_VCPKG_POSTSCRIPT%"
+DEL "%Z_VCPKG_POSTSCRIPT%"
 
 goto :fin
 
@@ -413,7 +413,7 @@ goto fin:
 
 :BOOTSTRAP
 :: add the cmdline args to the environment so powershell can use them
-set /a i=0 & for %%a in (%*) do call :set %%a 
+set /a i=0 & for %%a in (%*) do call :set %%a
 
 set POWERSHELL_EXE=
 for %%i in (pwsh.exe powershell.exe) do (
@@ -428,7 +428,7 @@ set VCPKG_EXITCODE=%ERRORLEVEL%
 @for /f "delims==" %%_ in ('set ^|  findstr -i argz') do call :unset %%_
 
 :: if we're being asked to remove it,we're done.
-if "%REMOVE_CE%" EQU "TRUE" ( 
+if "%REMOVE_CE%" EQU "TRUE" (
   goto :fin
 )
 
@@ -436,7 +436,7 @@ if "%REMOVE_CE%" EQU "TRUE" (
 doskey ce="%VCPKG_ROOT%\ce.cmd" $*
 
 :fin
-SET VCPKG_POSTSCRIPT=
+SET Z_VCPKG_POSTSCRIPT=
 SET VCPKG_CMD=
 set VCPKG_NODE=
 

--- a/ce.ps1
+++ b/ce.ps1
@@ -4,7 +4,7 @@
 $ENV:NODE_OPTIONS="--enable-source-maps"
 
 
-function resolve { 
+function resolve {
     param ( [string] $name )
     $name = Resolve-Path $name -ErrorAction 0 -ErrorVariable _err
     if (-not($name)) { return $_err[0].TargetObject }
@@ -13,7 +13,7 @@ function resolve {
 }
 
 
-if( $ENV:VCPKG_ROOT ) { 
+if( $ENV:VCPKG_ROOT ) {
   $SCRIPT:VCPKG_ROOT=(resolve $ENV:VCPKG_ROOT)
   $ENV:VCPKG_ROOT=$VCPKG_ROOT
 } else {
@@ -23,19 +23,18 @@ if( $ENV:VCPKG_ROOT ) {
 
 # setup the postscript file
 # Generate 31 bits of randomness, to avoid clashing with concurrent executions.
-$env:VCPKG_POSTSCRIPT = resolve "${VCPKG_ROOT}/VCPKG_tmp_$(Get-Random -SetSeed $PID).ps1"
+$env:Z_VCPKG_POSTSCRIPT = resolve "${VCPKG_ROOT}/VCPKG_tmp_$(Get-Random -SetSeed $PID).ps1"
 
 node $PSScriptRoot/ce @args  --accept-eula
 
 # dot-source the postscript file to modify the environment
-if ($env:VCPKG_POSTSCRIPT -and (Test-Path $env:VCPKG_POSTSCRIPT)) {
-  # write-host (get-content -raw $env:VCPKG_POSTSCRIPT)
-  $content = get-content -raw $env:VCPKG_POSTSCRIPT
-  
-  if( $content ) {
-    iex $content 
-  }
-  Remove-Item -Force $env:VCPKG_POSTSCRIPT
-  remove-item -ea 0 -force env:VCPKG_POSTSCRIPT
-}
+if ($env:Z_VCPKG_POSTSCRIPT -and (Test-Path $env:Z_VCPKG_POSTSCRIPT)) {
+  # write-host (get-content -raw $env:Z_VCPKG_POSTSCRIPT)
+  $content = get-content -raw $env:Z_VCPKG_POSTSCRIPT
 
+  if( $content ) {
+    iex $content
+  }
+  Remove-Item -Force $env:Z_VCPKG_POSTSCRIPT
+  remove-item -ea 0 -force env:Z_VCPKG_POSTSCRIPT
+}

--- a/ce/lib/constants.ts
+++ b/ce/lib/constants.ts
@@ -2,5 +2,5 @@
 // Licensed under the MIT License.
 
 export const project = 'environment.yaml';
-export const undo = 'VCPKG_UNDO';
+export const undo = 'Z_VCPKG_UNDO';
 export const blank = '\n';

--- a/ce/lib/session.ts
+++ b/ce/lib/session.ts
@@ -24,7 +24,7 @@ const defaultConfig =
   `# Global configuration
 
 global:
-  send-anonymous-telemetry: true 
+  send-anonymous-telemetry: true
   accepted-eula: false
 `;
 
@@ -183,7 +183,7 @@ export class Session {
 
   #postscriptFile?: Uri;
   get postscriptFile() {
-    return this.#postscriptFile || (this.#postscriptFile = this.environment['VCPKG_POSTSCRIPT'] ? this.fileSystem.file(this.environment['VCPKG_POSTSCRIPT']) : undefined);
+    return this.#postscriptFile || (this.#postscriptFile = this.environment['Z_VCPKG_POSTSCRIPT'] ? this.fileSystem.file(this.environment['Z_VCPKG_POSTSCRIPT']) : undefined);
   }
 
   async init() {
@@ -401,4 +401,3 @@ export class Session {
     return value;
   }
 }
-


### PR DESCRIPTION
vcpkg follows a convention for user-exposed things like switches and environment variables:

plain things are user settings with full support intended to be stabilized "forever"
X_ things are "experimental" things which eventually are intended to enter the previous "full support" category.
Z_ things are "internal, not intended for users to touch" and can change at any time.

As the variables VCPKG_POSTSCRIPT and VCPKG_UNDO are in the "internal" bucket, they should get Z_.

(There's also a bunch of trailing whitespace VS Code removed on its own when doing the find and replace)